### PR TITLE
dev: add gcloud cli to codespace

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,7 +2,9 @@
 // README at: https://github.com/rocker-org/devcontainer-templates/tree/main/src/r-ver
 {
   "name": "R (rocker/r-ver base)",
-  "image": "ghcr.io/rocker-org/devcontainer/r-ver:4.3",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "features": {
       "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
           "packages": "libudunits2-dev,libxtst6,libxt6,libmagick++-dev"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/rocker-org/devcontainer/r-ver:4.3
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && apt-get update -y \
+  && apt-get install google-cloud-sdk -y


### PR DESCRIPTION
This PR adds the gcloud CLI to the devcontainer setup, so people can access files on google cloud storage easily.